### PR TITLE
fix: corrects broken and missing links in the resource documentation

### DIFF
--- a/src/config/navigation.jsx
+++ b/src/config/navigation.jsx
@@ -64,7 +64,7 @@ export const navigation = [
       { title: 'Random Number', href: '/docs/resources/random/random_number' },
       { title: 'Random Password', href: '/docs/resources/random/random_password' },
       { title: 'Random UUID', href: '/docs/resources/random/random_uuid' },
-      { title: 'Remote Exec', href: '/docs/resources/random/remote_exec' },
+      { title: 'Remote Exec', href: '/docs/resources/exec/remote_exec' },
       { title: 'Root Certificate', href: '/docs/resources/cert/certificate_ca' },
       { title: 'Sidecar', href: '/docs/resources/container/sidecar' },
       { title: 'Task', href: '/docs/resources/docs/task' },

--- a/src/pages/docs/resources/docs/docs.mdx
+++ b/src/pages/docs/resources/docs/docs.mdx
@@ -3,5 +3,5 @@
 <Intro>
 Documentation is work in progress, please see the old documentation at:
 
-https://shipyard.run/docs/resources/docs
+https://shipyard.run/docs/resources/documentation
 </Intro>

--- a/src/pages/docs/resources/helm/index.mdx
+++ b/src/pages/docs/resources/helm/index.mdx
@@ -7,7 +7,7 @@ The `helm` resource allows Helm charts to be provisioned to `k8s_cluster` resour
 
 Documentation is work in progress, please see the old documentation at:
 
-https://shipyard.run/docs/resources/exec_remote
+https://shipyard.run/docs/resources/helm
 </Intro>
 
 ## Properties


### PR DESCRIPTION
I came across some broken links to the shipyard.run website along with a 404 on the main website when looking at the docs for resources. This should fix them up