### PR TITLE
fix: remove the `v` prefix when pulling a release

### DIFF
--- a/public/install
+++ b/public/install
@@ -39,7 +39,7 @@ fi
 version="$(curl -s -L https://jumppad.dev/latest)"
 binary="jumppad_${version}_${JUMPPAD_OS}_${JUMPPAD_ARCH}.${JUMPPAD_EXT}"
 
-repo="https://github.com/jumppad-labs/jumppad/releases/download/v${version}"
+repo="https://github.com/jumppad-labs/jumppad/releases/download/${version}"
 
 echo "Downloading $repo/$binary"
 rm -f /tmp/jumppad.${JUMPPAD_EXT}


### PR DESCRIPTION
## Problem
Since 0.6.0 jumppad stopped prefixing releases with a `v`, see: https://github.com/jumppad-labs/jumppad/releases

Which resulted in the error: 

```
Installing Jumppad to /usr/local/bin/jumppad

Please note: You may be prompted for your password

To remove Jumppad and all configuration use the command "jumppad uninstall"

Downloading https://github.com/jumppad-labs/jumppad/releases/download/v0.9.1/jumppad_0.9.1_darwin_arm64.zip
Unzipping download
Archive:  jumppad.zip
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
...
```

## Fix
Simply remove the `v` from when pointing to the release URL.

## Additional notes
- On the docs, installation through Brew was a bit farther down the page, so my simple brain turned to the `install.sh`.
Would it be helpful to move the "Package managers" section a bit higher? I'll happily raise a follow-up PR.

- `install.sh` should raise the NotFound error, and not try to unzip something that isn't downloaded.