### PR TITLE
Fix critical documentation errors

### DIFF
--- a/src/pages/docs/cli/overview.mdx
+++ b/src/pages/docs/cli/overview.mdx
@@ -52,7 +52,7 @@ jumppad completion zsh > "${fpath[1]}/_jumppad"
 echo "autoload -U compinit; compinit" >> ~/.zshrc
 
 # Install the completion code for jumppad into the oh-my-zsh completion folder
-jumppad completion zsh > ~/.oh-my-zsh/completions/_shipyard
+jumppad completion zsh > ~/.oh-my-zsh/completions/_jumppad
 ```
 
 ```shell {{ title: "fish" }}

--- a/src/pages/docs/introduction/installation.mdx
+++ b/src/pages/docs/introduction/installation.mdx
@@ -19,7 +19,7 @@ The quick install script allows you to easily install the latest version of Jump
 curl https://jumppad.dev/install | bash
 ```
 
-You should see the following output if the Installation is sucessful.
+You should see the following output if the Installation is successful.
 
 ```txt
 ################################
@@ -28,7 +28,7 @@ Installing Jumppad to /usr/local/bin/jumppad
 Please note: You may be prompted for your password
 
 To remove Jumppad and all configuration use the command "jumppad uninstall"
-Downloading https://github.com/jumppad-labs/jumppad/releases/download/v0.1.0/jumppad_0.1.0_linux_x86_64.tar.gz
+Downloading https://github.com/jumppad-labs/jumppad/releases/download/v0.20.1/jumppad_0.20.1_linux_x86_64.tar.gz
 /usr/bin/sudo
 [sudo] password for nicj: 
 


### PR DESCRIPTION
  ## Summary
  - Fix spelling error: "sucessful" → "successful" in installation docs
  - Update version reference: v0.1.0 → v0.20.1 in installation docs
  - Fix oh-my-zsh completion reference: _shipyard → _jumppad

  ## Test plan
  - [x] Verified all changes compile correctly
  - [x] Checked spelling and grammar fixes
  - [x] Confirmed version numbers are accurate
  - [x] Validated completion script references

  🤖 Generated with [Claude Code](https://claude.ai/code)